### PR TITLE
Update background image CSS for full coverage

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -103,12 +103,11 @@ input, select, textarea {
 		position: fixed;
 		right: 0;
 		bottom: 0;
-		min-width: 100vw;
-		min-height: 100vh;
-		width: auto;
-		height: auto;
+		width: 100%;
+		height: 100%;
 		z-index: -1;
 		object-fit: cover;
+		object-position: center;
 		pointer-events: none;
 	}
 


### PR DESCRIPTION
Revised the background image styles to use width and height at 100% instead of viewport units, added object-position center, and removed redundant properties. This ensures the image covers the container more reliably and is centered.